### PR TITLE
chore: fix arbitrary test delay

### DIFF
--- a/crates/yttrium/src/bundler/client.rs
+++ b/crates/yttrium/src/bundler/client.rs
@@ -63,7 +63,7 @@ impl BundlerClient {
 
         let user_operation_hash = response?;
 
-        Ok(user_operation_hash)
+        Ok(user_operation_hash.unwrap())
     }
 
     pub async fn estimate_user_operation_gas(
@@ -108,7 +108,7 @@ impl BundlerClient {
 
         let response_estimate = response?;
 
-        Ok(response_estimate)
+        Ok(response_estimate.unwrap())
     }
 
     pub async fn supported_entry_points(
@@ -132,7 +132,7 @@ impl BundlerClient {
     pub async fn get_user_operation_receipt(
         &self,
         hash: String,
-    ) -> eyre::Result<UserOperationReceipt> {
+    ) -> eyre::Result<Option<UserOperationReceipt>> {
         let bundler_url = self.config.url().clone();
 
         let hash_value = serde_json::to_value(&hash)?;
@@ -180,7 +180,7 @@ impl BundlerClient {
 
         loop {
             match self.get_user_operation_receipt(hash.clone()).await {
-                eyre::Result::Ok(receipt) => return Ok(receipt),
+                eyre::Result::Ok(Some(receipt)) => return Ok(receipt),
                 _ => {
                     if let Some(timeout_duration) = timeout {
                         if start_time.elapsed() > timeout_duration {
@@ -351,7 +351,7 @@ mod tests {
             .get_user_operation_receipt(user_operation_hash.clone())
             .await?;
 
-        eyre::ensure!(receipt == response_payload);
+        assert_eq!(receipt, Some(response_payload));
 
         Ok(())
     }

--- a/crates/yttrium/src/bundler/pimlico/client.rs
+++ b/crates/yttrium/src/bundler/pimlico/client.rs
@@ -48,6 +48,7 @@ impl BundlerClient {
         let response: Response<GasPrice> = v.into();
 
         let response_estimate = response?;
+        let response_estimate = response_estimate.unwrap();
 
         Ok(response_estimate)
     }

--- a/crates/yttrium/src/bundler/pimlico/paymaster/client.rs
+++ b/crates/yttrium/src/bundler/pimlico/paymaster/client.rs
@@ -66,6 +66,7 @@ impl PaymasterClient {
         let response: Response<SponsorshipResponseV07> = v.into();
 
         let response_estimate = response?;
+        let response_estimate = response_estimate.unwrap();
 
         let result = SponsorshipResultV07 {
             call_gas_limit: response_estimate.call_gas_limit,

--- a/crates/yttrium/src/jsonrpc.rs
+++ b/crates/yttrium/src/jsonrpc.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use thiserror::Error;
 
-pub type Response<T> = Result<T, ErrorPayload<T>>;
+pub type Response<T> = Result<Option<T>, ErrorPayload<T>>;
 
 #[derive(Debug, Deserialize, Error)]
 pub struct ErrorPayload<T> {
@@ -28,14 +28,14 @@ pub struct JSONRPCResponse<T> {
 impl<T> Into<Response<T>> for JSONRPCResponse<T> {
     fn into(self) -> Response<T> {
         if let Some(result) = self.result {
-            return Ok(result);
+            return Ok(Some(result));
         }
 
         if let Some(error) = self.error {
             return Err(error);
         }
 
-        panic!("Malformed response");
+        Ok(None)
     }
 }
 

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -440,15 +440,6 @@ mod tests {
 
         println!("Received User Operation hash: {:?}", user_operation_hash);
 
-        // TODO convert to polling
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let receipt = bundler_client
-            .get_user_operation_receipt(user_operation_hash.clone())
-            .await?;
-
-        println!("Received User Operation receipt: {:?}", receipt);
-
         println!("Querying for receipts...");
 
         let receipt = bundler_client

--- a/crates/yttrium/src/transaction/send/simple_account_test.rs
+++ b/crates/yttrium/src/transaction/send/simple_account_test.rs
@@ -236,22 +236,13 @@ mod tests {
             )
             .await?;
 
-        println!("Received User Operation hash: {:?}", user_operation_hash);
-
-        // TODO convert to polling
-        tokio::time::sleep(Duration::from_secs(2)).await;
-
-        let receipt = bundler_client
-            .get_user_operation_receipt(user_operation_hash.clone())
-            .await?;
-
-        println!("Received User Operation receipt: {:?}", receipt);
-
         println!("Querying for receipts...");
 
         let receipt = bundler_client
             .wait_for_user_operation_receipt(user_operation_hash.clone())
             .await?;
+
+        println!("Received User Operation receipt: {:?}", receipt);
 
         let tx_hash = receipt.receipt.transaction_hash;
         println!(


### PR DESCRIPTION
Fixes test flakiness due to hardcoded delay. Seems we were doing the same operation twice (once 1 time and second in a polling operation), so removed the redundant one. Needed to tweak the types a little.