### PR TITLE
fix: balance transfer & deployed txn

### DIFF
--- a/crates/yttrium/Cargo.toml
+++ b/crates/yttrium/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 
 [dependencies]
 # Ethereum
-alloy = { git = "https://github.com/alloy-rs/alloy", rev = "b000e16", features = [
+alloy = { git = "https://github.com/alloy-rs/alloy", version = "0.3.2", features = [
     "contract",
     "network",
     "providers",
@@ -48,5 +48,4 @@ wiremock = "0.6.0"
 reqwest.workspace = true
 
 [build-dependencies]
-alloy-primitives = { version = "0.7.0" }
 serde_json = "1"

--- a/crates/yttrium/src/bundler/pimlico/paymaster/models.rs
+++ b/crates/yttrium/src/bundler/pimlico/paymaster/models.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 pub struct UserOperationPreSponsorshipV07 {
     pub sender: Address,
     pub nonce: U256,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factory: Option<Address>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub factory_data: Option<Bytes>,
     pub call_data: Bytes,
     pub call_gas_limit: U256,

--- a/crates/yttrium/src/entry_point.rs
+++ b/crates/yttrium/src/entry_point.rs
@@ -40,6 +40,20 @@ pub const ENTRYPOINT_ADDRESS_V07: &str =
 pub const ENTRYPOINT_V06_TYPE: &str = "v0.6";
 pub const ENTRYPOINT_V07_TYPE: &str = "v0.7";
 
+sol! (
+    struct PackedUserOperation {
+        address sender;
+        uint256 nonce;
+        bytes initCode;
+        bytes callData;
+        bytes32 accountGasLimits;
+        uint256 preVerificationGas;
+        bytes32 gasFees;
+        bytes paymasterAndData;
+        bytes signature;
+    }
+);
+
 sol!(
     #[allow(missing_docs)]
     #[sol(rpc)]

--- a/crates/yttrium/src/entry_point/get_sender_address.rs
+++ b/crates/yttrium/src/entry_point/get_sender_address.rs
@@ -60,6 +60,10 @@ where
 
     let call_builder = instance.getSenderAddress(init_code);
 
+    // Note: you may need to static call getSenderAddress() not call() as per
+    // the spec. Leaving as-is for now.
+    // let call = call_builder.call_raw().await;
+
     let call: Result<
         crate::entry_point::EntryPoint::getSenderAddressReturn,
         ContractError,

--- a/crates/yttrium/src/smart_accounts/nonce.rs
+++ b/crates/yttrium/src/smart_accounts/nonce.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::U256;
+use alloy::primitives::aliases::U192;
 
 pub async fn get_nonce<P, T, N>(
     provider: &P,
@@ -14,7 +14,7 @@ where
         entry_point_address.to_address(),
         provider,
     );
-    let key = U256::ZERO;
+    let key = U192::ZERO;
 
     let get_nonce_call =
         entry_point_instance.getNonce(address.to_address(), key).call().await?;

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -1,6 +1,6 @@
 use alloy::{
     dyn_abi::DynSolValue,
-    primitives::{address, keccak256, Address, Bytes, Uint, U160, U256},
+    primitives::{address, keccak256, Address, Bytes, Uint, U256},
     providers::ReqwestProvider,
     sol,
     sol_types::{SolCall, SolValue},
@@ -174,11 +174,9 @@ pub async fn get_account_address(
     let initializer = get_initializer_code(owners.clone());
     let deployment_code = DynSolValue::Tuple(vec![
         DynSolValue::Bytes(creation_code.to_vec()),
-        DynSolValue::Uint(
-            Uint::<256, 4>::from(
-                U160::try_from(SAFE_ERC_7579_LAUNCHPAD_ADDRESS).unwrap(),
-            ),
-            256,
+        DynSolValue::FixedBytes(
+            SAFE_ERC_7579_LAUNCHPAD_ADDRESS.into_word(),
+            32,
         ),
     ])
     .abi_encode_packed();

--- a/crates/yttrium/src/smart_accounts/safe.rs
+++ b/crates/yttrium/src/smart_accounts/safe.rs
@@ -1,8 +1,9 @@
 use alloy::{
     dyn_abi::DynSolValue,
-    primitives::{address, keccak256, Address, Bytes, Uint, U256},
+    primitives::{address, keccak256, Address, Bytes, Uint, U160, U256},
+    providers::ReqwestProvider,
     sol,
-    sol_types::SolCall,
+    sol_types::{SolCall, SolValue},
 };
 
 sol!(
@@ -157,4 +158,39 @@ pub fn factory_data(
         initializer,
         saltNonce: U256::ZERO,
     }
+}
+
+pub async fn get_account_address(
+    provider: ReqwestProvider,
+    owners: Owners,
+) -> Address {
+    let creation_code =
+        SafeProxyFactory::new(SAFE_PROXY_FACTORY_ADDRESS, provider.clone())
+            .proxyCreationCode()
+            .call()
+            .await
+            .unwrap()
+            ._0;
+    let initializer = get_initializer_code(owners.clone());
+    let deployment_code = DynSolValue::Tuple(vec![
+        DynSolValue::Bytes(creation_code.to_vec()),
+        DynSolValue::Uint(
+            Uint::<256, 4>::from(
+                U160::try_from(SAFE_ERC_7579_LAUNCHPAD_ADDRESS).unwrap(),
+            ),
+            256,
+        ),
+    ])
+    .abi_encode_packed();
+    let salt = keccak256(
+        DynSolValue::Tuple(vec![
+            DynSolValue::FixedBytes(
+                keccak256(initializer.abi_encode_packed()),
+                32,
+            ),
+            DynSolValue::Uint(Uint::from(0), 256),
+        ])
+        .abi_encode_packed(),
+    );
+    SAFE_PROXY_FACTORY_ADDRESS.create2(salt, keccak256(deployment_code))
 }

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -61,7 +61,9 @@ mod tests {
     use alloy::{
         dyn_abi::{DynSolValue, Eip712Domain},
         network::Ethereum,
-        primitives::{Address, Bytes, FixedBytes, Uint, U128, U256},
+        primitives::{
+            aliases::U48, Address, Bytes, FixedBytes, Uint, U128, U256,
+        },
         providers::{ext::AnvilApi, Provider, ReqwestProvider},
         signers::{k256::ecdsa::SigningKey, local::LocalSigner, SignerSync},
         sol,
@@ -243,8 +245,8 @@ mod tests {
             op
         };
 
-        let valid_after = 0;
-        let valid_until = 0;
+        let valid_after = U48::from(0);
+        let valid_until = U48::from(0);
 
         sol!(
             struct SafeOp {

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -45,25 +45,26 @@ mod tests {
                 paymaster::client::PaymasterClient,
             },
         },
-        entry_point::get_sender_address::get_sender_address_v07,
+        config::Config,
         smart_accounts::{
             nonce::get_nonce,
             safe::{
-                factory_data, Execution, Owners, Safe7579, Safe7579Launchpad,
-                SAFE_4337_MODULE_ADDRESS, SAFE_ERC_7579_LAUNCHPAD_ADDRESS,
-                SAFE_PROXY_FACTORY_ADDRESS,
+                factory_data, get_account_address, Execution, Owners, Safe7579,
+                Safe7579Launchpad, SAFE_4337_MODULE_ADDRESS,
+                SAFE_ERC_7579_LAUNCHPAD_ADDRESS, SAFE_PROXY_FACTORY_ADDRESS,
                 SEPOLIA_SAFE_ERC_7579_SINGLETON_ADDRESS,
             },
             simple_account::{factory::FactoryAddress, SimpleAccountAddress},
         },
-        transaction::Transaction,
         user_operation::UserOperationV07,
     };
     use alloy::{
         dyn_abi::{DynSolValue, Eip712Domain},
         network::Ethereum,
         primitives::{Address, Bytes, FixedBytes, Uint, U128, U256},
-        providers::{Provider, ReqwestProvider},
+        providers::{
+            ext::AnvilApi, PendingTransactionConfig, Provider, ReqwestProvider,
+        },
         signers::{k256::ecdsa::SigningKey, local::LocalSigner, SignerSync},
         sol,
         sol_types::{SolCall, SolValue},
@@ -71,7 +72,7 @@ mod tests {
     use std::{ops::Not, str::FromStr};
 
     async fn send_transaction(
-        transaction: Transaction,
+        execution_calldata: Vec<Execution>,
         owner: LocalSigner<SigningKey>,
     ) -> eyre::Result<String> {
         let config = crate::config::Config::local();
@@ -107,22 +108,8 @@ mod tests {
 
         let factory_data_value = factory_data(owners.clone()).abi_encode();
 
-        let sender_address = get_sender_address_v07(
-            &provider,
-            safe_factory_address.into(),
-            factory_data_value.clone().into(),
-            entry_point_address,
-        )
-        .await?;
-
-        let to: Address = transaction.to.parse()?;
-        let value: alloy::primitives::Uint<256, 4> =
-            transaction.value.parse()?;
-        let data_hex = transaction.data.strip_prefix("0x").unwrap();
-        let data: Bytes = Bytes::from_str(data_hex)?;
-
-        let execution_calldata =
-            vec![Execution { target: to, value, callData: data }];
+        let sender_address =
+            get_account_address(provider.clone(), owners.clone()).await;
 
         let call_type = if execution_calldata.len() > 1 {
             CallType::BatchCall
@@ -358,7 +345,7 @@ mod tests {
         let verifying_contract = if erc7579_launchpad_address && !deployed {
             sponsored_user_op.sender
         } else {
-            SAFE_ERC_7579_LAUNCHPAD_ADDRESS
+            SAFE_4337_MODULE_ADDRESS
         };
 
         // TODO loop per-owner
@@ -409,19 +396,74 @@ mod tests {
             tx_hash
         );
 
+        // Some extra calls to wait for/get the actual transaction. But these
+        // aren't required since eth_getUserOperationReceipt already waits
+        // let tx_hash = FixedBytes::from_slice(
+        //     &hex::decode(tx_hash.strip_prefix("0x").unwrap()).unwrap(),
+        // );
+        // let pending_txn = provider
+        //     .watch_pending_transaction(PendingTransactionConfig::new(tx_hash))
+        //     .await?;
+        // pending_txn.await.unwrap();
+        // let transaction = provider.get_transaction_by_hash(tx_hash).await?;
+        // println!("Transaction included: {:?}", transaction);
+        // let transaction_receipt =
+        //     provider.get_transaction_receipt(tx_hash).await?;
+        // println!("Transaction receipt: {:?}", transaction_receipt);
+
         Ok(user_operation_hash)
     }
 
     #[tokio::test]
     async fn test_send_transaction() -> eyre::Result<()> {
-        let transaction = Transaction::mock();
+        let rpc_url = Config::local().endpoints.rpc.base_url;
+        let rpc_url: reqwest::Url = rpc_url.parse()?;
+        let provider = ReqwestProvider::<Ethereum>::new_http(rpc_url);
+
+        let destination = LocalSigner::random();
+        let balance = provider.get_balance(destination.address()).await?;
+        assert_eq!(balance, Uint::from(0));
 
         let owner = LocalSigner::random();
+        let sender_address = get_account_address(
+            provider.clone(),
+            Owners { owners: vec![owner.address()], threshold: 1 },
+        )
+        .await;
+
+        provider.anvil_set_balance(sender_address, U256::from(100)).await?;
+        let transaction = vec![Execution {
+            target: destination.address(),
+            value: Uint::from(1),
+            callData: Bytes::new(),
+        }];
+
+        let transaction_hash =
+            send_transaction(transaction, owner.clone()).await?;
+
+        println!("Transaction sent: {}", transaction_hash);
+
+        let balance = provider.get_balance(destination.address()).await?;
+        assert_eq!(balance, Uint::from(1));
+
+        provider.anvil_set_balance(sender_address, U256::from(100)).await?;
+        let transaction = vec![Execution {
+            target: destination.address(),
+            value: Uint::from(1),
+            callData: Bytes::new(),
+        }];
 
         let transaction_hash = send_transaction(transaction, owner).await?;
 
         println!("Transaction sent: {}", transaction_hash);
 
+        let balance = provider.get_balance(destination.address()).await?;
+        assert_eq!(balance, Uint::from(2));
+
         Ok(())
     }
+
+    // TODO test/fix: if invalid call data (e.g. sending balance that you don't
+    // have), the account will still be deployed but the transfer won't happen.
+    // Why can't we detect this?
 }

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -68,7 +68,7 @@ mod tests {
         sol,
         sol_types::{SolCall, SolValue},
     };
-    use std::{ops::Not, str::FromStr, time::Duration};
+    use std::{ops::Not, str::FromStr};
 
     async fn send_transaction(
         transaction: Transaction,
@@ -144,21 +144,14 @@ mod tests {
         let data_hex = transaction.data.strip_prefix("0x").unwrap();
         let data: Bytes = Bytes::from_str(data_hex)?;
 
-        // let execution_calldata =
-        //     vec![Execution { target: to, value, callData: data }];
-        // let execution_calldata =
-        //     Execution { target: to, value, callData: data };
         let execution_calldata =
-            [to.to_vec(), value.to_be_bytes_vec(), data.to_vec()]
-                .concat()
-                .into();
+            vec![Execution { target: to, value, callData: data }];
 
-        // let call_type = if execution_calldata.len() > 1 {
-        //     CallType::BatchCall
-        // } else {
-        //     CallType::Call
-        // };
-        let call_type = CallType::Call;
+        let call_type = if execution_calldata.len() > 1 {
+            CallType::BatchCall
+        } else {
+            CallType::Call
+        };
         let revert_on_error = false;
         let selector = [0u8; 4];
         let context = [0u8; 22];
@@ -179,25 +172,18 @@ mod tests {
             }
         }
 
-        let mut mode = Vec::with_capacity(32);
-        mode.push(call_type.as_byte());
-        mode.push(if revert_on_error { 0x01 } else { 0x00 });
-        mode.extend_from_slice(&[0u8; 4]);
-        mode.extend_from_slice(&selector);
-        mode.extend_from_slice(&context);
-        let mode = FixedBytes::from_slice(&mode);
-
-        // let mode = DynSolValue::Tuple(vec![
-        //     DynSolValue::Uint(Uint::from(call_type.as_byte()), 8),
-        //     DynSolValue::Uint(Uint::from(revert_on_error as u8), 8),
-        //     DynSolValue::Bytes(selector.to_vec().into()),
-        //     DynSolValue::Bytes(context.to_vec().into()),
-        // ]).abi_encode_packed().into();
+        let mode = DynSolValue::Tuple(vec![
+            DynSolValue::Uint(Uint::from(call_type.as_byte()), 8),
+            DynSolValue::Uint(Uint::from(revert_on_error as u8), 8),
+            DynSolValue::Bytes(vec![0u8; 4]),
+            DynSolValue::Bytes(selector.to_vec()),
+            DynSolValue::Bytes(context.to_vec()),
+        ])
+        .abi_encode_packed();
 
         let call_data = Safe7579::executeCall {
-            mode,
-            // executionCalldata: execution_calldata.abi_encode().into(),
-            executionCalldata: execution_calldata,
+            mode: FixedBytes::from_slice(&mode),
+            executionCalldata: execution_calldata.abi_encode_packed().into(),
         }
         .abi_encode()
         .into();

--- a/crates/yttrium/src/transaction/send/safe_test.rs
+++ b/crates/yttrium/src/transaction/send/safe_test.rs
@@ -62,9 +62,7 @@ mod tests {
         dyn_abi::{DynSolValue, Eip712Domain},
         network::Ethereum,
         primitives::{Address, Bytes, FixedBytes, Uint, U128, U256},
-        providers::{
-            ext::AnvilApi, PendingTransactionConfig, Provider, ReqwestProvider,
-        },
+        providers::{ext::AnvilApi, Provider, ReqwestProvider},
         signers::{k256::ecdsa::SigningKey, local::LocalSigner, SignerSync},
         sol,
         sol_types::{SolCall, SolValue},

--- a/crates/yttrium/src/transaction/send/simple_account_test.rs
+++ b/crates/yttrium/src/transaction/send/simple_account_test.rs
@@ -63,7 +63,7 @@ mod tests {
         providers::ProviderBuilder,
         signers::local::LocalSigner,
     };
-    use std::{str::FromStr, time::Duration};
+    use std::str::FromStr;
 
     async fn send_transaction(
         transaction: Transaction,


### PR DESCRIPTION
Adds test coverage for transferring native token balance from the smart account to another account. It does this transfer twice, the first time as part of the account deployment, and the second against the deployed account.

This fixes some issues in the process:
- Sponsor transaction should have `undefined` `factory` and `factoryData` when working against a deployed account
- Switch to manual `CREATE2` implementation as `getSenderAddress()` only works when the account isn't yet deployed
- General code refactors and cleanup