### PR TITLE
chore: improve Swift build

### DIFF
--- a/crates/ffi/build-rust-ios.sh
+++ b/crates/ffi/build-rust-ios.sh
@@ -30,7 +30,7 @@ lipo \
     ./../../target/universal-ios/debug/lib$PACKAGE_NAME.a
 
 function create_package {
-  cargo install -f swift-bridge-cli
+  cargo install swift-bridge-cli
   swift-bridge-cli create-package \
         --bridges-dir ./generated \
         --out-dir $SWIFT_PACKAGE_NAME \

--- a/crates/ffi/build.rs
+++ b/crates/ffi/build.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 fn main() {
     let out_dir = PathBuf::from("./generated");
-        println!("cargo:rerun-if-changed={}", out_dir.display());
+    println!("cargo:rerun-if-changed={}", out_dir.display());
 
     let bridges = vec!["src/lib.rs"];
     for path in &bridges {

--- a/crates/ffi/build.rs
+++ b/crates/ffi/build.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 fn main() {
     let out_dir = PathBuf::from("./generated");
+        println!("cargo:rerun-if-changed={}", out_dir.display());
 
     let bridges = vec!["src/lib.rs"];
     for path in &bridges {


### PR DESCRIPTION
- Removes the force install of `swift-bridge-cli` to optimize speed of devloop
- Reruns the generation of Swift bindings if they are deleted